### PR TITLE
chore(PortSanitizer): use `between?` to set the default port

### DIFF
--- a/lib/port_sanitizer.rb
+++ b/lib/port_sanitizer.rb
@@ -8,8 +8,8 @@ class PortSanitizer
 
     port = port.to_i
 
-    if port < 1024 || port > 49151
-      puts "#{color.yellow('Invalid or no port informed. Assigning default port (8125)')}.\n\n"
+    unless port.between?(1024, 49151)
+      puts "#{color.yellow("Invalid or no port informed. Assigning default port (#{DEFAULT_PORT})")}.\n\n"
 
       return DEFAULT_PORT
     end


### PR DESCRIPTION
This is a small change that, I guess, will increase readability.

Great work btw 😉 
