### PR TITLE
Specify binding host

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,16 @@ $ mini_statsd
 
 Simple as that :)
 
-If you want to set a specific port, just run:
+If you want to set a specific port and binding host, just run:
 
 ```shell
-$ mini_statsd <port>
+$ mini_statsd <port> <host>
 ```
 
 Like:
 
 ```shell
-$ mini_statsd 9125
+$ mini_statsd 9125 0.0.0.0
 ```
 
 A simple example of a code that sends the statsd message from the gif can be found [here](https://gist.github.com/IgorMarques/079b08c3bbb13e8d896151a192262e8b)

--- a/lib/mini_statsd.rb
+++ b/lib/mini_statsd.rb
@@ -2,6 +2,6 @@ require_relative 'statsd_listener'
 
 class MiniStatsd
   def self.run(args = [])
-    StatsdListener.run(port: args.first)
+    StatsdListener.run(port: args[0], host: args[1])
   end
 end

--- a/lib/statsd_listener.rb
+++ b/lib/statsd_listener.rb
@@ -16,7 +16,7 @@ class StatsdListener
 
     @socket = UDPSocket.new
     @port = PortSanitizer.sanitize(port)
-    @host = host
+    @host = host.nil? ? '127.0.0.1' : host
 
     @socket.bind(@host, @port)
   end

--- a/lib/statsd_listener.rb
+++ b/lib/statsd_listener.rb
@@ -5,23 +5,24 @@ require_relative 'port_sanitizer'
 class StatsdListener
   include Term::ANSIColor
 
-  def self.run(port)
+  def self.run(port: nil, host: nil)
     puts "Starting MiniStatsd...\n\n"
 
-    new(port).run
+    new(host: host, port: port).run
   end
 
-  def initialize(port:)
+  def initialize(host: nil, port: nil)
     $stdout.sync = true
 
     @socket = UDPSocket.new
     @port = PortSanitizer.sanitize(port)
+    @host = host
 
-    @socket.bind(nil, @port)
+    @socket.bind(@host, @port)
   end
 
   def run
-    puts "Listening on port #{@port}"
+    puts "Listening on #{@host}:#{@port}"
 
     while @message = @socket.recvfrom(@port)
       extract_metric


### PR DESCRIPTION
This allows the binging host to be specified. Currently the gem works if running on a local machine and using localhost for the statsd metrics. If we want to run the gem inside a Docker container, the binding host is not reachable. This PR allows the host to be set, so we can use '0.0.0.0' to run this inside Docker.

Due to the port being the first parameter, the host is now the second parameter to introduce no breaking changes. It would be good to see the parameters of the host and port as named arguments `--port 1111` instead of  `args[0]`, but that would be a breaking change for this gem.